### PR TITLE
Remove unused Supabase auth helper packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
     "next": "14.2.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "@supabase/supabase-js": "2.39.7",
-    "@supabase/auth-helpers-react": "0.5.7",
-    "@supabase/auth-helpers-nextjs": "0.5.7"
+    "@supabase/supabase-js": "2.39.7"
   },
   "devDependencies": {
     "autoprefixer": "10.4.16",


### PR DESCRIPTION
## Summary
- remove `@supabase/auth-helpers-react` and `@supabase/auth-helpers-nextjs`

## Testing
- `npm install` *(fails: 403 Forbidden due to offline environment)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652e199778832a81252fb05263a8bf