### PR TITLE
Next.js rewrite with Supabase auth context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Inventory Next.js App
 
-This is a rewrite of the original inventory management app using Next.js App Router and Supabase. It supports authentication, product management, sales logs and links per user.
+This is a rewrite of the original inventory management app using Next.js App Router and Supabase. It supports authentication, product management, sales logs and links per user. The codebase uses TypeScript and organizes logic under `app/`, `components/`, `context/` and `lib/`.
 
 ## Environment Variables
 Copy `.env.example` to `.env.local` and fill in your Supabase project credentials.

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useState, useEffect } from 'react';
-import { useSession, useSupabase } from '../../components/AuthProvider';
+import { useSession, useSupabase } from '../../context/AuthContext';
 import { useRouter } from 'next/navigation';
 
 interface Sale {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import './globals.css';
 import { ReactNode } from 'react';
-import AuthProvider from '../components/AuthProvider';
+import { AuthProvider } from '../context/AuthContext';
 import Nav from '../components/Nav';
 import ThemeToggle from '../components/ThemeToggle';
 

--- a/app/links/page.tsx
+++ b/app/links/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useState, useEffect } from 'react';
-import { useSession, useSupabase } from '../../components/AuthProvider';
+import { useSession, useSupabase } from '../../context/AuthContext';
 import { useRouter } from 'next/navigation';
 
 interface LinkItem {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { useSession, useSupabase } from '../../components/AuthProvider';
+import { useSession, useSupabase } from '../../context/AuthContext';
 
 export default function LoginPage() {
   const supabase = useSupabase();
@@ -9,6 +9,7 @@ export default function LoginPage() {
   const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [isSignUp, setIsSignUp] = useState(false);
   const [error, setError] = useState('');
 
   if (session) {
@@ -16,17 +17,19 @@ export default function LoginPage() {
     return null;
   }
 
-  const handleLogin = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    const { error } = isSignUp
+      ? await supabase.auth.signUp({ email, password })
+      : await supabase.auth.signInWithPassword({ email, password });
     if (error) setError(error.message);
     else router.replace('/products');
   };
 
   return (
     <div className="max-w-sm mx-auto">
-      <h1 className="text-2xl mb-4">Login</h1>
-      <form onSubmit={handleLogin} className="flex flex-col gap-2">
+      <h1 className="text-2xl mb-4">{isSignUp ? 'Sign Up' : 'Login'}</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
         <input
           className="border p-2"
           type="email"
@@ -43,9 +46,18 @@ export default function LoginPage() {
         />
         {error && <p className="text-red-600">{error}</p>}
         <button className="bg-blue-600 text-white p-2" type="submit">
-          Sign In
+          {isSignUp ? 'Create Account' : 'Sign In'}
         </button>
       </form>
+      <button
+        onClick={() => {
+          setIsSignUp(!isSignUp);
+          setError('');
+        }}
+        className="underline mt-2"
+      >
+        {isSignUp ? 'Already have an account? Sign in' : 'Need an account? Sign up'}
+      </button>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useSession } from '../components/AuthProvider';
+import { useSession } from '../context/AuthContext';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { useSession, useSupabase } from '../../components/AuthProvider';
+import { useSession, useSupabase } from '../../context/AuthContext';
 
 interface Product {
   id: number;

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -1,6 +1,6 @@
 'use client'
 import Link from 'next/link';
-import { useSession, useSupabase } from './AuthProvider';
+import { useSession, useSupabase } from '../context/AuthContext';
 import { useRouter } from 'next/navigation';
 
 export default function Nav() {

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -1,11 +1,7 @@
 'use client'
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { createClient, Session, SupabaseClient } from '@supabase/supabase-js';
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-
-export const supabase: SupabaseClient = createClient(supabaseUrl, supabaseAnonKey);
+import { Session } from '@supabase/supabase-js';
+import { supabase } from '../lib/supabaseClient';
 
 interface AuthContextType {
   session: Session | null;
@@ -13,7 +9,7 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType>({ session: null });
 
-export default function AuthProvider({ children }: { children: ReactNode }) {
+export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
 
   useEffect(() => {

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,0 +1,8 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+export default supabase;


### PR DESCRIPTION
## Summary
- add `lib/supabaseClient.ts`
- move auth provider to `context/AuthContext`
- update imports for the new auth context
- enhance login page with sign-up support
- document updated project structure

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653312a4e8832a873633fb1c48769d