### PR TITLE
Implement edit and sell features

### DIFF
--- a/app/products/[id]/edit/page.tsx
+++ b/app/products/[id]/edit/page.tsx
@@ -1,0 +1,71 @@
+'use client'
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSession, useSupabase } from '../../../../context/AuthContext';
+
+interface Product {
+  id: number;
+  name: string;
+  quantity: number;
+  price: number;
+  cost: number;
+  image_url: string | null;
+}
+
+export default function EditProductPage({ params }: { params: { id: string } }) {
+  const supabase = useSupabase();
+  const session = useSession();
+  const router = useRouter();
+  const [product, setProduct] = useState<Product | null>(null);
+  const [name, setName] = useState('');
+  const [quantity, setQuantity] = useState(0);
+  const [price, setPrice] = useState(0);
+  const [cost, setCost] = useState(0);
+
+  useEffect(() => {
+    if (!session) {
+      router.replace('/login');
+    } else {
+      fetchProduct();
+    }
+  }, [session]);
+
+  async function fetchProduct() {
+    const { data } = await supabase
+      .from('products')
+      .select('*')
+      .eq('id', Number(params.id))
+      .single();
+    if (data) {
+      setProduct(data);
+      setName(data.name);
+      setQuantity(data.quantity);
+      setPrice(data.price);
+      setCost(data.cost);
+    }
+  }
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await supabase
+      .from('products')
+      .update({ name, quantity, price, cost })
+      .eq('id', Number(params.id));
+    router.push('/products');
+  };
+
+  if (!product) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h1 className="text-2xl mb-4">Edit Product</h1>
+      <form onSubmit={handleSave} className="flex flex-col gap-2">
+        <input className="border p-2" value={name} onChange={(e) => setName(e.target.value)} />
+        <input className="border p-2" type="number" value={quantity} onChange={(e) => setQuantity(Number(e.target.value))} />
+        <input className="border p-2" type="number" value={price} onChange={(e) => setPrice(Number(e.target.value))} />
+        <input className="border p-2" type="number" value={cost} onChange={(e) => setCost(Number(e.target.value))} />
+        <button className="bg-blue-600 text-white p-2" type="submit">Save</button>
+      </form>
+    </div>
+  );
+}

--- a/app/products/[id]/sell/page.tsx
+++ b/app/products/[id]/sell/page.tsx
@@ -1,0 +1,86 @@
+'use client'
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSession, useSupabase } from '../../../../context/AuthContext';
+
+interface Product {
+  id: number;
+  name: string;
+  quantity: number;
+  price: number;
+  cost: number;
+}
+
+export default function SellProductPage({ params }: { params: { id: string } }) {
+  const supabase = useSupabase();
+  const session = useSession();
+  const router = useRouter();
+  const [product, setProduct] = useState<Product | null>(null);
+  const [units, setUnits] = useState(1);
+  const [sellPrice, setSellPrice] = useState(0);
+
+  useEffect(() => {
+    if (!session) {
+      router.replace('/login');
+    } else {
+      fetchProduct();
+    }
+  }, [session]);
+
+  async function fetchProduct() {
+    const { data } = await supabase
+      .from('products')
+      .select('*')
+      .eq('id', Number(params.id))
+      .single();
+    if (data) {
+      setProduct(data);
+      setSellPrice(data.price);
+    }
+  }
+
+  const handleSell = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!product) return;
+    if (units <= 0 || units > product.quantity) return;
+    await supabase.from('sales').insert({
+      user_id: session!.user.id,
+      product_id: product.id,
+      quantity: units,
+      price: sellPrice,
+    });
+    await supabase
+      .from('products')
+      .update({ quantity: product.quantity - units })
+      .eq('id', product.id);
+    router.push('/products');
+  };
+
+  if (!product) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h1 className="text-2xl mb-4">Sell {product.name}</h1>
+      <p className="mb-2">In Stock: {product.quantity}</p>
+      <form onSubmit={handleSell} className="flex flex-col gap-2">
+        <input
+          className="border p-2"
+          type="number"
+          value={units}
+          onChange={(e) => setUnits(Number(e.target.value))}
+          min={1}
+          max={product.quantity}
+        />
+        <input
+          className="border p-2"
+          type="number"
+          value={sellPrice}
+          onChange={(e) => setSellPrice(Number(e.target.value))}
+        />
+        <button className="bg-blue-600 text-white p-2" type="submit">
+          Confirm
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -71,6 +71,11 @@ export default function ProductsPage() {
     fetchProducts();
   };
 
+  const handleDelete = async (id: number) => {
+    await supabase.from('products').delete().eq('id', id);
+    fetchProducts();
+  };
+
   return (
     <div>
       <h1 className="text-2xl mb-4">Products</h1>
@@ -84,8 +89,28 @@ export default function ProductsPage() {
       </form>
       <ul className="space-y-2">
         {products.map((p) => (
-          <li key={p.id} className="border p-2 flex justify-between">
-            <span>{p.name} ({p.quantity})</span>
+          <li key={p.id} className="border p-2 flex flex-col gap-1">
+            {p.image_url && (
+              <img src={p.image_url} alt={p.name} className="w-32 mb-2" />
+            )}
+            <span className="font-semibold">{p.name}</span>
+            <span>Qty: {p.quantity}</span>
+            <span>Price: £{p.price}</span>
+            <span>Cost: £{p.cost}</span>
+            <div className="flex gap-2 mt-2">
+              <a href={`/products/${p.id}/sell`} className="underline">
+                Sell
+              </a>
+              <a href={`/products/${p.id}/edit`} className="underline">
+                Edit
+              </a>
+              <button
+                onClick={() => handleDelete(p.id)}
+                className="underline text-red-600"
+              >
+                Delete
+              </button>
+            </div>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- expand product listing with controls for selling and editing
- add product deletion utility
- create edit and sell pages for each product

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686539f0e0f0832a96c4a6c203274b01